### PR TITLE
Lv3/transaction: findById() in절 쿼리 현상 발생

### DIFF
--- a/src/main/generated/org/example/expert/domain/log/manager/QManagerReqLog.java
+++ b/src/main/generated/org/example/expert/domain/log/manager/QManagerReqLog.java
@@ -1,0 +1,55 @@
+package org.example.expert.domain.log.manager;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QManagerReqLog is a Querydsl query type for ManagerReqLog
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QManagerReqLog extends EntityPathBase<ManagerReqLog> {
+
+    private static final long serialVersionUID = 25437972L;
+
+    public static final QManagerReqLog managerReqLog = new QManagerReqLog("managerReqLog");
+
+    public final org.example.expert.domain.common.entity.QTimestamped _super = new org.example.expert.domain.common.entity.QTimestamped(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath message = createString("message");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final NumberPath<Long> requestUserId = createNumber("requestUserId", Long.class);
+
+    public final EnumPath<ManagerReqStatus> status = createEnum("status", ManagerReqStatus.class);
+
+    public final NumberPath<Long> targetUserId = createNumber("targetUserId", Long.class);
+
+    public final NumberPath<Long> todoId = createNumber("todoId", Long.class);
+
+    public QManagerReqLog(String variable) {
+        super(ManagerReqLog.class, forVariable(variable));
+    }
+
+    public QManagerReqLog(Path<? extends ManagerReqLog> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QManagerReqLog(PathMetadata metadata) {
+        super(ManagerReqLog.class, metadata);
+    }
+
+}
+

--- a/src/main/java/org/example/expert/aop/ManagerReqLogAspect.java
+++ b/src/main/java/org/example/expert/aop/ManagerReqLogAspect.java
@@ -27,15 +27,15 @@ public class ManagerReqLogAspect {
         ManagerLogContext managerLogContext = ManagerLogContext.validateAndCreate(joinPoint.getArgs());
         try{
             Object result = joinPoint.proceed();
-            String message = ManagerLogMessage.ASSIGNED_SUCCESS.format(managerLogContext.getRequest().getManagerUserId(), managerLogContext.getTodoId());
+            String message = ManagerLogMessage.ASSIGNED_SUCCESS.format(managerLogContext.getRequest().getTargetUserId(), managerLogContext.getTodoId());
             saveLog(managerLogContext, message, ManagerReqStatus.SUCCESS, null);
             return result;
         }catch (InvalidRequestException e) {
-            String message = ManagerLogMessage.ASSIGNED_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getManagerUserId());
+            String message = ManagerLogMessage.ASSIGNED_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getTargetUserId());
             saveLog(managerLogContext, message, ManagerReqStatus.FAIL, e);
             throw e;
         }catch(Exception e){
-            String message = ManagerLogMessage.INTERNAL_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getManagerUserId());
+            String message = ManagerLogMessage.INTERNAL_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getTargetUserId());
             saveLog(managerLogContext, message, ManagerReqStatus.FAIL, e);
             throw e;
         }

--- a/src/main/java/org/example/expert/aop/ManagerReqLogAspect.java
+++ b/src/main/java/org/example/expert/aop/ManagerReqLogAspect.java
@@ -1,0 +1,56 @@
+package org.example.expert.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.example.expert.aop.dto.ManagerLogContext;
+import org.example.expert.domain.common.exception.InvalidRequestException;
+import org.example.expert.domain.log.manager.ManagerLogMessage;
+import org.example.expert.domain.log.manager.ManagerReqStatus;
+import org.example.expert.domain.log.manager.service.ManagerReqLogService;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ManagerReqLogAspect {
+    private static final String MANAGER_SAVE_POINTCUT =
+            "execution(* org.example.expert.domain.manager.service.ManagerService.saveManager(..))";
+
+    private final ManagerReqLogService logService;
+
+    @Around(MANAGER_SAVE_POINTCUT)
+    public Object logManagerAssignment(ProceedingJoinPoint joinPoint) throws Throwable{
+        ManagerLogContext managerLogContext = ManagerLogContext.validateAndCreate(joinPoint.getArgs());
+        try{
+            Object result = joinPoint.proceed();
+            String message = ManagerLogMessage.ASSIGNED_SUCCESS.format(managerLogContext.getRequest().getManagerUserId(), managerLogContext.getTodoId());
+            saveLog(managerLogContext, message, ManagerReqStatus.SUCCESS, null);
+            return result;
+        }catch (InvalidRequestException e) {
+            String message = ManagerLogMessage.ASSIGNED_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getManagerUserId());
+            saveLog(managerLogContext, message, ManagerReqStatus.FAIL, e);
+            throw e;
+        }catch(Exception e){
+            String message = ManagerLogMessage.INTERNAL_FAIL.format(e.getMessage(), managerLogContext.getTodoId(), managerLogContext.getRequest().getManagerUserId());
+            saveLog(managerLogContext, message, ManagerReqStatus.FAIL, e);
+            throw e;
+        }
+    }
+
+    private void saveLog (ManagerLogContext context, String message, ManagerReqStatus status, Exception originalException) {
+        try {
+            logService.saveLog(context.getRequest(), status, context.getUser(), context.getTodoId(), message);
+        } catch (Exception logError) {
+            if (originalException == null) {
+                //비즈니스는 성공적으로 수행됐으나 로그 저장에 실패한 경우
+                log.warn(ManagerLogMessage.LOG_SAVE_FAIL_WITH_ERROR.getFormat(), logError.getMessage(), logError);
+            } else {
+                log.warn(ManagerLogMessage.LOG_SAVE_FAIL_WITH_ERROR.getFormat(), originalException.getMessage(), logError.getMessage(), logError);
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/expert/aop/dto/ManagerLogContext.java
+++ b/src/main/java/org/example/expert/aop/dto/ManagerLogContext.java
@@ -1,0 +1,64 @@
+package org.example.expert.aop.dto;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.example.expert.domain.common.exception.ServerException;
+import org.example.expert.domain.manager.dto.request.ManagerSaveRequest;
+import org.example.expert.domain.log.manager.ManagerLogMessage;
+import org.example.expert.domain.user.entity.User;
+
+
+@Getter
+@Slf4j
+public class ManagerLogContext {
+    public static final int ARGS_COUNT = 3;
+    private final User user;
+    private final Long todoId;
+    private final ManagerSaveRequest request;
+
+    private ManagerLogContext(User user, Long todoId, ManagerSaveRequest request) {
+        this.user = user;
+        this.todoId = todoId;
+        this.request = request;
+    }
+
+    public static ManagerLogContext validateAndCreate(Object[] args){
+        validateArgs(args);
+        return new ManagerLogContext(
+                (User) args[0],
+                (Long) args[1],
+                (ManagerSaveRequest) args[2]
+        );
+    }
+
+    private static void validateArgs(Object[] args) {
+        validateArgsCount(args);
+        validateArgsType(args);
+    }
+
+    private static void validateArgsCount(Object[] args) {
+        if (args.length != ARGS_COUNT) {
+            String errorMsg = ManagerLogMessage.INVALIDATE_ARGS_COUNT.format(ARGS_COUNT, args.length);
+            log.error("ManagerLogContext 생성 실패: {}", errorMsg);
+            throw new ServerException(errorMsg);
+        }
+    }
+
+    private static void validateArgsType(Object[] args) {
+        if (!(args[0] instanceof User)) {
+            String errorMsg = ManagerLogMessage.INVALIDATE_USER_TYPE.format(args[0]!= null? args[0].getClass().getName(): "null");
+            log.error("ManagerLogContext 생성 실패: {}", errorMsg);
+            throw new ServerException(errorMsg);
+        }
+        if (!(args[1] instanceof Long)) {
+            String errorMsg = ManagerLogMessage.INVALIDATE_TODO_ID_TYPE.format(args[1] != null ? args[1].getClass().getName() : "null");
+            log.error("ManagerLogContext 생성 실패: {}", errorMsg);
+            throw new ServerException(errorMsg);
+        }
+        if (!(args[2] instanceof ManagerSaveRequest)) {
+            String errorMsg = ManagerLogMessage.INVALIDATE_REQUEST_TYPE.format(args[2] != null ? args[2].getClass().getName() : "null");
+            log.error("ManagerLogContext 생성 실패: {}", errorMsg);
+            throw new ServerException(errorMsg);
+        }
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/manager/ManagerLogMessage.java
+++ b/src/main/java/org/example/expert/domain/log/manager/ManagerLogMessage.java
@@ -1,0 +1,33 @@
+package org.example.expert.domain.log.manager;
+
+import lombok.Getter;
+import org.example.expert.aop.dto.ManagerLogContext;
+
+@Getter
+public enum ManagerLogMessage {
+
+    ASSIGNED_SUCCESS("담당자 배정 완료: (todoId: %d, targetUserId: %d)"),
+    ASSIGNED_FAIL("담당자 배정 실패: %s (todoId: %d, targetUserId: %d)"),
+    INTERNAL_FAIL("담당자 배정 중 오류 발생: %s (todoId: %d, targetUserId: %d)"),
+
+    //로그 저장
+    LOG_SAVE_FAIL_WITH_SUCCESS("로그 저장 실패. 담당자 배정은 정상 처리 완료. 실패 이유: {}"),
+    LOG_SAVE_FAIL_WITH_ERROR("로그 저장 실패. 원본 에러: {}. 로그 저장 실패 이유: {}"),
+
+    //ManagerLogContext 검증
+    INVALIDATE_ARGS_COUNT("담당자 배정 로그를 남기기 위한 인수 개수가 부적절합니다. 필요: %d, 실제: %d"),
+    INVALIDATE_USER_TYPE("첫 번째 인수는 User 타입이어야 합니다 (들어온 타입: %s)"),
+    INVALIDATE_TODO_ID_TYPE("두 번째 인수는 Long 타입이어야 합니다 (들어온 타입: %s)"),
+    INVALIDATE_REQUEST_TYPE("세 번째 인수는 ManagerSaveRequest 타입이어야 합니다 (들어온 타입: %s)");
+
+    private final String format;
+
+    ManagerLogMessage(String format) {
+        this.format = format;
+    }
+
+    public String format(Object... args) {
+        return String.format(format, args);
+    }
+
+}

--- a/src/main/java/org/example/expert/domain/log/manager/ManagerReqLog.java
+++ b/src/main/java/org/example/expert/domain/log/manager/ManagerReqLog.java
@@ -1,0 +1,44 @@
+package org.example.expert.domain.log.manager;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.common.entity.Timestamped;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "log")
+public class ManagerReqLog extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long requestUserId;  // 요청한 유저
+
+    @Column(nullable = false)
+    private Long targetUserId;   // 담당자로 지정하려는 유저
+
+    @Column(nullable = false)
+    private Long todoId;         // 할일
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private ManagerReqStatus status;       // 요청 처리 상태 (성공/실패)
+
+    @Column(nullable = false)
+    private String message;      // 상세 메시지 (성공/실패 사유 등....)
+
+    @Builder
+    public ManagerReqLog(Long requestUserId, Long targetUserId, Long todoId, ManagerReqStatus status, String message) {
+        this.requestUserId = requestUserId;
+        this.targetUserId = targetUserId;
+        this.todoId = todoId;
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/manager/ManagerReqLogRepository.java
+++ b/src/main/java/org/example/expert/domain/log/manager/ManagerReqLogRepository.java
@@ -1,0 +1,9 @@
+package org.example.expert.domain.log.manager;
+
+import org.example.expert.domain.log.manager.ManagerReqLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ManagerReqLogRepository extends JpaRepository<ManagerReqLog, Long> {
+}

--- a/src/main/java/org/example/expert/domain/log/manager/ManagerReqStatus.java
+++ b/src/main/java/org/example/expert/domain/log/manager/ManagerReqStatus.java
@@ -1,0 +1,8 @@
+package org.example.expert.domain.log.manager;
+
+import lombok.Getter;
+
+@Getter
+public enum ManagerReqStatus {
+    SUCCESS, FAIL
+}

--- a/src/main/java/org/example/expert/domain/log/manager/service/ManagerReqLogService.java
+++ b/src/main/java/org/example/expert/domain/log/manager/service/ManagerReqLogService.java
@@ -1,0 +1,31 @@
+package org.example.expert.domain.log.manager.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.manager.dto.request.ManagerSaveRequest;
+import org.example.expert.domain.log.manager.ManagerReqLog;
+import org.example.expert.domain.log.manager.ManagerReqStatus;
+import org.example.expert.domain.log.manager.ManagerReqLogRepository;
+import org.example.expert.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerReqLogService {
+
+    private final ManagerReqLogRepository logRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveLog(ManagerSaveRequest managerSaveRequest, ManagerReqStatus status, User user, Long todoId, String message){
+        ManagerReqLog log = ManagerReqLog.builder()
+                .requestUserId(user.getId())
+                .targetUserId(managerSaveRequest.getManagerUserId())
+                .todoId(todoId)
+                .status(status)
+                .message(message)
+                .build();
+        logRepository.save(log);
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/manager/service/ManagerReqLogService.java
+++ b/src/main/java/org/example/expert/domain/log/manager/service/ManagerReqLogService.java
@@ -21,7 +21,7 @@ public class ManagerReqLogService {
     public void saveLog(ManagerSaveRequest managerSaveRequest, ManagerReqStatus status, User user, Long todoId, String message){
         ManagerReqLog log = ManagerReqLog.builder()
                 .requestUserId(user.getId())
-                .targetUserId(managerSaveRequest.getManagerUserId())
+                .targetUserId(managerSaveRequest.getTargetUserId())
                 .todoId(todoId)
                 .status(status)
                 .message(message)

--- a/src/main/java/org/example/expert/domain/manager/dto/request/ManagerSaveRequest.java
+++ b/src/main/java/org/example/expert/domain/manager/dto/request/ManagerSaveRequest.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 public class ManagerSaveRequest {
 
     @NotNull
-    private Long managerUserId; // 일정 작상자가 배치하는 유저 id
+    private Long targetUserId; // 일정 작상자가 배치하는 유저 id
 }

--- a/src/main/java/org/example/expert/domain/manager/dto/response/ManagerSaveResponse.java
+++ b/src/main/java/org/example/expert/domain/manager/dto/response/ManagerSaveResponse.java
@@ -1,16 +1,18 @@
 package org.example.expert.domain.manager.dto.response;
 
 import lombok.Getter;
+import org.example.expert.domain.manager.entity.Manager;
 import org.example.expert.domain.user.dto.response.UserResponse;
+import org.example.expert.domain.user.entity.User;
 
 @Getter
 public class ManagerSaveResponse {
 
     private final Long id;
-    private final UserResponse user;
+    private final UserResponse userInfo;
 
-    public ManagerSaveResponse(Long id, UserResponse user) {
-        this.id = id;
-        this.user = user;
+    public ManagerSaveResponse(Manager manager) {
+        this.id = manager.getId();
+        this.userInfo = new UserResponse(manager.getUser());
     }
 }

--- a/src/main/java/org/example/expert/domain/manager/entity/Manager.java
+++ b/src/main/java/org/example/expert/domain/manager/entity/Manager.java
@@ -18,7 +18,7 @@ public class Manager {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false) // 일정 만든 사람 id
+    @JoinColumn(name = "user_id", nullable = false) // 일정에 배정된 유저 (일정 생성자는 일정 생성 시 cascade에 따라 자동 배정)
     private User user;
     @ManyToOne(fetch = FetchType.LAZY) // 일정 id
     @JoinColumn(name = "todo_id", nullable = false)

--- a/src/main/java/org/example/expert/domain/manager/repository/ManagerRepository.java
+++ b/src/main/java/org/example/expert/domain/manager/repository/ManagerRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ManagerRepository extends JpaRepository<Manager, Long> {
     @Query("SELECT m FROM Manager m JOIN FETCH m.user WHERE m.todo.id = :todoId")
     List<Manager> findByTodoIdWithUser(@Param("todoId") Long todoId);
+
+    Optional<Manager> findByUserIdAndTodoId(Long userId, Long todoId);
 }

--- a/src/main/java/org/example/expert/domain/manager/repository/ManagerRepository.java
+++ b/src/main/java/org/example/expert/domain/manager/repository/ManagerRepository.java
@@ -1,6 +1,8 @@
 package org.example.expert.domain.manager.repository;
 
 import org.example.expert.domain.manager.entity.Manager;
+import org.example.expert.domain.todo.entity.Todo;
+import org.example.expert.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,5 +14,5 @@ public interface ManagerRepository extends JpaRepository<Manager, Long> {
     @Query("SELECT m FROM Manager m JOIN FETCH m.user WHERE m.todo.id = :todoId")
     List<Manager> findByTodoIdWithUser(@Param("todoId") Long todoId);
 
-    Optional<Manager> findByUserIdAndTodoId(Long userId, Long todoId);
+    Optional<Manager> findByUserAndTodo(@Param(value = "user") User user , @Param(value = "todo") Todo todo);
 }

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -52,7 +52,7 @@ public class ManagerService {
         }
 
         User managerUser = userRepository.findById(managerSaveRequest.getManagerUserId())
-                .orElseThrow(() -> new InvalidRequestException("등록하려고 하는 담당자 유저가 존재하지 않습니다"));
+                .orElseThrow(() -> new InvalidRequestException("등록하려고 하는 유저가 존재하지 않습니다"));
 
         if (ObjectUtils.nullSafeEquals(user.getId(), managerUser.getId())) {
             throw new InvalidRequestException("일정 작성자는 본인을 담당자로 등록할 수 없습니다");

--- a/src/main/java/org/example/expert/domain/todo/entity/Todo.java
+++ b/src/main/java/org/example/expert/domain/todo/entity/Todo.java
@@ -43,9 +43,15 @@ public class Todo extends Timestamped {
         this.managers.add(new Manager(user, this));
     }
 
-    public void isOwner(Long userId){
-        if (!ObjectUtils.nullSafeEquals(userId, this.getUser().getId())) {
+    public void isOwner(User user){
+        if (!ObjectUtils.nullSafeEquals(user.getId(), this.user.getId())) {
             throw new InvalidRequestException("해당 일정을 만든 유저여야 합니다");
+        }
+    }
+
+    public void validateManagerAssignment(User targetUser){
+        if (ObjectUtils.nullSafeEquals(this.user.getId(), targetUser.getId())) {
+            throw new InvalidRequestException("일정 작성자는 본인을 담당자로 등록할 수 없습니다");
         }
     }
 }


### PR DESCRIPTION
### saveManager()시 userRepository.findById()에서 유저 조회 쿼리가 in절로 나가는 현상 발생
- **원인**: 기존 default_batch_size 설정과 하이버네이트 프록시 최적화 전략이 맞물려서 PC에 이미 프록시 User가 있는 상황에서 userRepository를 통해 다른 User 엔티티를 조회하려 할 때 한꺼번에 가져오도록 내부 동작 자동 발생
- **해결 방안**: User를 먼저 조회하도록 순서를 바꿔서 프록시 배치 로딩 최적화가 일어나지 않도록 함